### PR TITLE
amend drop duplicate behaviour in starter notebook

### DIFF
--- a/starter_notebook.ipynb
+++ b/starter_notebook.ipynb
@@ -328,12 +328,8 @@
     }
    ],
    "source": [
-    "# drop duplicate translations\n",
-    "df_pp = df.drop_duplicates()\n",
-    "\n",
-    "# drop conflicting translations\n",
-    "df_pp.drop_duplicates(subset='source_sentence', inplace=True)\n",
-    "df_pp.drop_duplicates(subset='target_sentence', inplace=True)"
+    "# drop duplicate translations when source AND target are duplicates\n",
+    "df_pp = df.drop_duplicates(subset=['source_sentence', 'target_sentence'], inplace=True)"
    ]
   },
   {
@@ -1040,7 +1036,20 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed drop duplicate behaviour to remove rows only when source **AND** target text are duplicates. Allowing for instances when source text may have multiple valid translations